### PR TITLE
Akaze def max keypoints

### DIFF
--- a/benchmarks/benches/feature_extraction.rs
+++ b/benchmarks/benches/feature_extraction.rs
@@ -40,6 +40,7 @@ fn extract_features_from_image(bencher: Bencher, sample_size: u32) {
                 sample_size as usize,
             )
             .unwrap(),
+            None
         )
     });
 }

--- a/feature_extraction/src/lib.rs
+++ b/feature_extraction/src/lib.rs
@@ -66,7 +66,7 @@ pub fn akaze_keypoint_descriptor_extraction_def(img: &Mat, max_points: Option<i3
         4,
         4,
         KAZE_DiffusivityType::DIFF_PM_G2,
-        max_points.unwrap_or(262143),
+        max_points.unwrap_or(2_i32.pow(18)-1),
     )?;
 
     let mut akaze_keypoints = Vector::default();

--- a/feature_extraction/src/lib.rs
+++ b/feature_extraction/src/lib.rs
@@ -246,8 +246,6 @@ mod test {
             img1_matched_points.len(),
             img2_matched_points.len()
         );
-
-        assert!(true);
     }
 
     #[test]

--- a/feature_extraction/src/lib.rs
+++ b/feature_extraction/src/lib.rs
@@ -261,12 +261,12 @@ mod test {
         println!(
             "{} - Keypoints: {}",
             img1_dir,
-            img1_keypoints.keypoints.len()
+            img1_keypoints.len()
         );
         println!(
             "{} - Keypoints: {}",
             img2_dir,
-            img2_keypoints.keypoints.len()
+            img2_keypoints.len()
         );
 
         assert!(img1_keypoints.len() == 9079 && img2_keypoints.len() == 9357);

--- a/feature_extraction/src/lib.rs
+++ b/feature_extraction/src/lib.rs
@@ -9,6 +9,9 @@ use opencv::core::Ptr;
 
 use opencv::{self as cv, prelude::*};
 
+pub const MAX_POINTS_SHIFT: i32 = 18
+pub const MAX_POINTS: i32 = (1 << MAX_POINTS_SHIFT) - 1
+    
 pub struct ExtractedKeyPoint {
     keypoints: Vector<KeyPoint>,
     descriptors: Mat,
@@ -66,7 +69,7 @@ pub fn akaze_keypoint_descriptor_extraction_def(img: &Mat, max_points: Option<i3
         4,
         4,
         KAZE_DiffusivityType::DIFF_PM_G2,
-        max_points.unwrap_or(2_i32.pow(18)-1),
+        max_points.unwrap_or(MAX_POINTS),
     )?;
 
     let mut akaze_keypoints = Vector::default();

--- a/feature_extraction/src/lib.rs
+++ b/feature_extraction/src/lib.rs
@@ -9,8 +9,8 @@ use opencv::core::Ptr;
 
 use opencv::{self as cv, prelude::*};
 
-pub const MAX_POINTS_SHIFT: i32 = 18
-pub const MAX_POINTS: i32 = (1 << MAX_POINTS_SHIFT) - 1
+pub const MAX_POINTS_SHIFT: i32 = 18;
+pub const MAX_POINTS: i32 = (1 << MAX_POINTS_SHIFT) - 1;
     
 pub struct ExtractedKeyPoint {
     keypoints: Vector<KeyPoint>,

--- a/feature_extraction/src/lib.rs
+++ b/feature_extraction/src/lib.rs
@@ -55,7 +55,7 @@ impl ExtractedKeyPoint {
     }
 }
 
-pub fn akaze_keypoint_descriptor_extraction_def(img: &Mat) -> Result<ExtractedKeyPoint, Error> {
+pub fn akaze_keypoint_descriptor_extraction_def(img: &Mat, max_points: Option<i32>) -> Result<ExtractedKeyPoint, Error> {
     //let img: Mat = cv::imgcodecs::imread(file_location, cv::imgcodecs::IMREAD_COLOR).unwrap();
 
     let mut akaze: Ptr<AKAZE> = <AKAZE>::create(
@@ -66,7 +66,7 @@ pub fn akaze_keypoint_descriptor_extraction_def(img: &Mat) -> Result<ExtractedKe
         4,
         4,
         KAZE_DiffusivityType::DIFF_PM_G2,
-        -1,
+        max_points.unwrap_or(262143),
     )?;
 
     let mut akaze_keypoints = Vector::default();
@@ -198,8 +198,8 @@ mod test {
         let img1: Mat = get_mat_from_dir(img1_dir).unwrap();
         let img2: Mat = get_mat_from_dir(img2_dir).unwrap();
 
-        let img1_keypoints = akaze_keypoint_descriptor_extraction_def(&img1).unwrap();
-        let img2_keypoints = akaze_keypoint_descriptor_extraction_def(&img2).unwrap();
+        let img1_keypoints = akaze_keypoint_descriptor_extraction_def(&img1, None).unwrap();
+        let img2_keypoints = akaze_keypoint_descriptor_extraction_def(&img2, None).unwrap();
 
         println!(
             "{} - Keypoints: {}",
@@ -255,8 +255,8 @@ mod test {
         let img1: Mat = get_mat_from_dir(img1_dir).unwrap();
         let img2: Mat = get_mat_from_dir(img2_dir).unwrap();
 
-        let img1_keypoints = akaze_keypoint_descriptor_extraction_def(&img1).unwrap().keypoints;
-        let img2_keypoints = akaze_keypoint_descriptor_extraction_def(&img2).unwrap().keypoints;
+        let img1_keypoints = akaze_keypoint_descriptor_extraction_def(&img1, None).unwrap().keypoints;
+        let img2_keypoints = akaze_keypoint_descriptor_extraction_def(&img2, None).unwrap().keypoints;
 
         println!(
             "{} - Keypoints: {}",
@@ -280,8 +280,8 @@ mod test {
         let img1: Mat = get_mat_from_dir(img1_dir).unwrap();
         let img2: Mat = get_mat_from_dir(img2_dir).unwrap();
 
-        let img1_keypoints = akaze_keypoint_descriptor_extraction_def(&img1).unwrap();
-        let img2_keypoints = akaze_keypoint_descriptor_extraction_def(&img2).unwrap();
+        let img1_keypoints = akaze_keypoint_descriptor_extraction_def(&img1, None).unwrap();
+        let img2_keypoints = akaze_keypoint_descriptor_extraction_def(&img2, None).unwrap();
 
         let matches = get_knn_matches(
             &img1_keypoints.descriptors,
@@ -302,8 +302,8 @@ mod test {
         let img1: Mat = get_mat_from_dir(img1_dir).unwrap();
         let img2: Mat = get_mat_from_dir(img2_dir).unwrap();
 
-        let img1_keypoints = akaze_keypoint_descriptor_extraction_def(&img1).unwrap();
-        let img2_keypoints = akaze_keypoint_descriptor_extraction_def(&img2).unwrap();
+        let img1_keypoints = akaze_keypoint_descriptor_extraction_def(&img1, None).unwrap();
+        let img2_keypoints = akaze_keypoint_descriptor_extraction_def(&img2, None).unwrap();
 
         let matches =
             get_bruteforce_matches(&img1_keypoints.descriptors, &img2_keypoints.descriptors)

--- a/preprocessor/src/main.rs
+++ b/preprocessor/src/main.rs
@@ -227,7 +227,7 @@ fn feature_extraction_to_database(
     let tile_mat = raster_to_mat(&tile, tile_size as i32, tile_size as i32)
         .expect("Could not convert tile to mat");
     // Extract keypoints and descriptors
-    let keypoints = akaze_keypoint_descriptor_extraction_def(&tile_mat.mat).unwrap();
+    let keypoints = akaze_keypoint_descriptor_extraction_def(&tile_mat.mat, None).unwrap();
 
     // Insert the image into the database.
     let insert_image = models::InsertImage {


### PR DESCRIPTION
Added an optional max_points argument to  `akaze_keypoint_descriptor_extraction_def`, and a default max keypoint count of 2^18-1 since `knn_match` will crash otherwise